### PR TITLE
Fixed wrong data type

### DIFF
--- a/apyefa/client.py
+++ b/apyefa/client.py
@@ -138,7 +138,7 @@ class EfaClient:
         format: CoordFormat = CoordFormat.WGS84,
         limit: int = 10,
         search_nearbly_stops: bool = False,
-    ) -> Location:
+    ) -> list[Location]:
         """
         Asynchronously fetches location information based on given coordinates.
 


### PR DESCRIPTION
This pull request includes a change to the `apyefa/client.py` file to improve the type hinting for the `location_by_coord` method.
@alex-jung Maybe change the naming scheme because of the not existing plural and singular difference?

Type hinting improvement:

* [`apyefa/client.py`](diffhunk://#diff-b4ab4c052e5e8d7c59b72cfa8a6eb2cf4f44f8781aebae1f5c34b9ff9e0600a7L141-R141): Modified the return type of the `location_by_coord` method from `Location` to `list[Location]`.