### PR TITLE
ALLOW_EXTRA for _SCHEMA_LEG

### DIFF
--- a/apyefa/data_classes.py
+++ b/apyefa/data_classes.py
@@ -240,7 +240,8 @@ _SCHEMA_LEG: Final = vol.Schema(
         vol.Optional("isRealtimeControlled"): vol.Boolean,
         vol.Optional("realtimeStatus"): list,
         vol.Optional("footPathInfo"): list,
-    }
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 


### PR DESCRIPTION
This pull request includes a small change to the `apyefa/data_classes.py` file. The change allows the schema to accept extra fields by adding the `extra=vol.ALLOW_EXTRA` parameter to the validation schema.

This error was accoured by `voluptuous.error.MultipleInvalid: extra keys not allowed @ data['fare']`
Also found:
```
coords | [ […], […], […], […], […], […], […], […], […], […], … ]
fare | Object { zones: […] }
properties | Object { vehicleAccess: […] }
```

* [`apyefa/data_classes.py`](diffhunk://#diff-db2962d370dbda33586a9f618c42336d36619d63cd0af079cd545f52074d41f9L243-R244): Added `extra=vol.ALLOW_EXTRA` to the schema to allow additional fields.